### PR TITLE
add a `results dir` to avoid err when make vuls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-results

--- a/results/.gitignore
+++ b/results/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  make
ls: cannot access '/home/ubuntu/go/src/github.com/future-architect/vuls/integration/results': No such file or directory
ls: cannot access '/home/ubuntu/go/src/github.com/future-architect/vuls/integration/results': No such file or directory
ls: cannot access '/home/ubuntu/go/src/github.com/future-architect/vuls/integration/results': No such file or directory