### PR TITLE
chore(lockfile): add pear/packagist installed.json fixture variants

### DIFF
--- a/data/lockfile/installed-packagist/installed.json
+++ b/data/lockfile/installed-packagist/installed.json
@@ -1,20 +1,6 @@
 {
   "packages": [
     {
-      "name": "pear/log",
-      "version": "1.13.3",
-      "version_normalized": "1.13.3.0",
-      "type": "library",
-      "install-path": "../pear/log"
-    },
-    {
-      "name": "pear/pear_exception",
-      "version": "v1.0.2",
-      "version_normalized": "1.0.2.0",
-      "type": "class",
-      "install-path": "../pear/pear_exception"
-    },
-    {
       "name": "guzzlehttp/psr7",
       "version": "1.8.3",
       "version_normalized": "1.8.3.0",

--- a/data/lockfile/installed-pear/installed.json
+++ b/data/lockfile/installed-pear/installed.json
@@ -1,0 +1,20 @@
+{
+  "packages": [
+    {
+      "name": "pear/log",
+      "version": "1.13.3",
+      "version_normalized": "1.13.3.0",
+      "type": "library",
+      "install-path": "../pear/log"
+    },
+    {
+      "name": "pear/pear_exception",
+      "version": "v1.0.2",
+      "version_normalized": "1.0.2.0",
+      "type": "class",
+      "install-path": "../pear/pear_exception"
+    }
+  ],
+  "dev": true,
+  "dev-package-names": []
+}

--- a/data/lockfile/installed.json
+++ b/data/lockfile/installed.json
@@ -1,6 +1,20 @@
 {
   "packages": [
     {
+      "name": "pear/log",
+      "version": "1.13.3",
+      "version_normalized": "1.13.3.0",
+      "type": "library",
+      "install-path": "../pear/log"
+    },
+    {
+      "name": "pear/pear_exception",
+      "version": "v1.0.2",
+      "version_normalized": "1.0.2.0",
+      "type": "class",
+      "install-path": "../pear/pear_exception"
+    },
+    {
       "name": "guzzlehttp/psr7",
       "version": "1.8.3",
       "version_normalized": "1.8.3.0",

--- a/int-config.toml
+++ b/int-config.toml
@@ -90,9 +90,13 @@ lockfiles = ["./integration/data/lockfile/uv.lock"]
 type = "pseudo"
 lockfiles = ["./integration/data/lockfile/composer.lock"]
 
-[servers.composer-vendor]
+[servers.composer-vendor-pear]
 type = "pseudo"
-lockfiles = ["./integration/data/lockfile/installed.json"]
+lockfiles = ["./integration/data/lockfile/installed-pear/installed.json"]
+
+[servers.composer-vendor-packagist]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/installed-packagist/installed.json"]
 
 [servers.npm-v1]
 type = "pseudo"

--- a/int-redis-config.toml
+++ b/int-redis-config.toml
@@ -90,9 +90,13 @@ lockfiles = ["./integration/data/lockfile/uv.lock"]
 type = "pseudo"
 lockfiles = ["./integration/data/lockfile/composer.lock"]
 
-[servers.composer-vendor]
+[servers.composer-vendor-pear]
 type = "pseudo"
-lockfiles = ["./integration/data/lockfile/installed.json"]
+lockfiles = ["./integration/data/lockfile/installed-pear/installed.json"]
+
+[servers.composer-vendor-packagist]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/installed-packagist/installed.json"]
 
 [servers.npm-v1]
 type = "pseudo"


### PR DESCRIPTION
## Summary
Add a minimal-form Composer 2.x `installed.json` fixture alongside the existing full-form one, and group both under per-shape sub-directories:

- New: `data/lockfile/installed-pear/installed.json` — entries with only `name`/`version`/`type`/`install-path` (`pear/log`, `pear/pear_exception`). Represents PEAR-style or hand-crafted vendor entries.
- Moved: `data/lockfile/installed.json` → `data/lockfile/installed-packagist/installed.json` — the existing Packagist-shape entries (`guzzlehttp/psr7`, `psr/http-message`, `ralouphie/getallheaders`) with full `source`/`dist`/`require`/`autoload` metadata. Content unchanged.

The directory-per-variant layout matches the convention already used for `npm-v1/v2/v3`, `poetry-v1/v2`, `conan-v1/v2`, etc.

`int-config.toml` and `int-redis-config.toml`: replace the single `[servers.composer-vendor]` entry with `[servers.composer-vendor-pear]` and `[servers.composer-vendor-packagist]`.

## Why
future-architect/vuls used to keep a duplicate of the Packagist-shape `installed.json` under `scanner/testdata/fixtures/installed.json`, plus its own minimal-form fixture. OpenSSF Scorecard ([alert future-architect/vuls#81](https://github.com/future-architect/vuls/security/code-scanning/81)) misread those duplicates as real vuls dependencies. Bringing the minimal-form fixture into this repo lets the companion vuls PR drop the duplicates and read both shapes from here, while still exercising the parser against each shape.

## Companion PR
future-architect/vuls#2531 — switches `TestAnalyzeLibrary_Golden` to read from this repo and pins the integration ref to the merge commit of this PR.

## Test plan
- [ ] Once merged, future-architect/vuls#2531 bumps the `ref:` SHA in `.github/workflows/test.yml` and the submodule pointer to this merge commit; CI on that PR exercises the two fixtures.