### PR TITLE
fix: set windows_10_21h2_old serverName to match its filename

### DIFF
--- a/data/results/windows_10_21h2_old.json
+++ b/data/results/windows_10_21h2_old.json
@@ -2,7 +2,7 @@
     "jsonVersion": 4,
     "lang": "",
     "serverUUID": "",
-    "serverName": "localhost",
+    "serverName": "windows_10_21h2_old",
     "family": "windows",
     "release": "Windows 10 Version 21H2 for x64-based Systems",
     "container": {
@@ -603,8 +603,8 @@
             "resultsDir": "C:\\Users\\user\\vuls\\results",
             "default": {},
             "servers": {
-                "localhost": {
-                    "serverName": "localhost",
+                "windows_10_21h2_old": {
+                    "serverName": "windows_10_21h2_old",
                     "host": "localhost",
                     "port": "local",
                     "scanMode": [


### PR DESCRIPTION
## Problem

`windows_10_21h2_old` reports **0** detected CVEs in the `vuls diff detection` guard for both baseline and target — so it always shows `0 / 0 / PASS` and is, in effect, silently excluded from the guard.

Root cause is not detection or data: vuls0 `report` writes its output to `<serverName>.json`, but the diff-detection harness reads results back by the **scan-result filename** (`pkg/db/diff/detection/detection.go`). This fixture's top-level `serverName` was `localhost` — the only Windows fixture whose `serverName` differs from its filename — so vuls0 wrote `localhost.json` while the harness read the untouched input `windows_10_21h2_old.json` (`scannedCves: {}`) and saw 0.

Verified locally: running vuls0 `report` directly on this fixture detects **3181** CVEs (expected for a 2023-era Windows 10 21H2 host), but the harness reads back 0.

## Fix

Align `serverName` (and the mirrored `config.scan.servers` entry) with the filename — the convention every other fixture already follows. The literal network `host` stays `localhost`.

After the change, `vuls diff detection` reads back the real **3181 / 3181** (0% change, PASS), restoring this fixture's coverage in the guard.

```diff
-    "serverName": "localhost",
+    "serverName": "windows_10_21h2_old",
...
-                "localhost": {
-                    "serverName": "localhost",
+                "windows_10_21h2_old": {
+                    "serverName": "windows_10_21h2_old",
                     "host": "localhost",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)