### PR TITLE
feat: add Seal Security patched-package lockfiles

### DIFF
--- a/data/lockfile/seal/go.mod
+++ b/data/lockfile/seal/go.mod
@@ -1,0 +1,7 @@
+module example.com/seal-demo-app
+
+go 1.22
+
+require golang.org/x/crypto v0.26.0
+
+replace golang.org/x/crypto => sealsecurity.io/golang.org/x/crypto v0.26.0-sp1

--- a/data/lockfile/seal/package-lock.json
+++ b/data/lockfile/seal/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "seal-demo-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "seal-demo-app",
+      "version": "1.0.0",
+      "dependencies": {
+        "ejs": "npm:@seal-security/ejs@2.7.4-sp1",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/ejs": {
+      "name": "@seal-security/ejs",
+      "version": "2.7.4-sp1",
+      "resolved": "https://registry.npmjs.org/@seal-security/ejs/-/ejs-2.7.4-sp1.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/data/lockfile/seal/requirements.txt
+++ b/data/lockfile/seal/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.32.3
+seal-django==3.2.18+sp1

--- a/int-config.toml
+++ b/int-config.toml
@@ -203,3 +203,15 @@ lockfiles = ["./integration/data/lockfile/Package.resolved"]
 [servers.rust-binary]
 type = "pseudo"
 lockfiles = ["./integration/data/lockfile/hello-rust"]
+
+[servers.seal-npm]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/package-lock.json"]
+
+[servers.seal-pip]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/requirements.txt"]
+
+[servers.seal-gomod]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/go.mod"]

--- a/int-redis-config.toml
+++ b/int-redis-config.toml
@@ -203,3 +203,15 @@ lockfiles = ["./integration/data/lockfile/Package.resolved"]
 [servers.rust-binary]
 type = "pseudo"
 lockfiles = ["./integration/data/lockfile/hello-rust"]
+
+[servers.seal-npm]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/package-lock.json"]
+
+[servers.seal-pip]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/requirements.txt"]
+
+[servers.seal-gomod]
+type = "pseudo"
+lockfiles = ["./integration/data/lockfile/seal/go.mod"]


### PR DESCRIPTION
Add lockfiles containing [Seal Security](https://www.seal.security/) patched packages for the vendor advisory detection introduced in trivy v0.71 (enabled in vuls by future-architect/vuls#2596).

Each file mixes a Seal-patched package with a standard one, so a single scan exercises both the vendor buckets (`seal npm::` etc.) and the standard ecosystem buckets of trivy-db:

| file | Seal package | standard package |
|---|---|---|
| `seal/package-lock.json` | `@seal-security/ejs@2.7.4-sp1` (npm alias install form) | `lodash@4.17.21` |
| `seal/requirements.txt` | `seal-django==3.2.18+sp1` | `requests==2.32.3` |
| `seal/go.mod` | `replace` → `sealsecurity.io/golang.org/x/crypto v0.26.0-sp1` | — |

Package names/versions are taken from the actual seal buckets of trivy-db (2026-07-03), so each Seal package matches real advisories (e.g. CVE-2024-33883 for ejs, CVE-2024-27351 for django, CVE-2025-22869 for x/crypto). Verified end-to-end with a vuls binary built from future-architect/vuls#2596: `vuls report` detects the seal-bucket CVEs for these lockfiles, while a master-built binary detects none of them.

Server entries are added to both `int-config.toml` and `int-redis-config.toml` (`seal-npm`, `seal-pip`, `seal-gomod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)