### PR TITLE
feat: add CPE pseudo-server scan results per cpe data source

### DIFF
--- a/data/results/cpe_cisco.json
+++ b/data/results/cpe_cisco.json
@@ -1,0 +1,26 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_cisco",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_cisco": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/o:cisco:ios:15.1",
+            "cpe:/o:cisco:ios:15.2",
+            "cpe:/o:cisco:ios_xe:16.3.1",
+            "cpe:/o:cisco:ios_xe:17.3.1",
+            "cpe:/a:cisco:adaptive_security_appliance_software:9.8.1",
+            "cpe:/a:cisco:adaptive_security_appliance_software:9.12.4"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/results/cpe_fortinet.json
+++ b/data/results/cpe_fortinet.json
@@ -1,0 +1,29 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_fortinet",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_fortinet": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/o:fortinet:fortios:7.0.0",
+            "cpe:/o:fortinet:fortios:6.4.0",
+            "cpe:/o:fortinet:fortios:6.0.0",
+            "cpe:/o:fortinet:fortios:5.6.0",
+            "cpe:/a:fortinet:fortiproxy:7.0.0",
+            "cpe:/a:fortinet:fortiweb:6.3.0",
+            "cpe:/a:fortinet:fortimanager:7.0.0",
+            "cpe:/a:fortinet:fortianalyzer:7.0.0",
+            "cpe:/a:fortinet:forticlient:6.0.0"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/results/cpe_jvn.json
+++ b/data/results/cpe_jvn.json
@@ -1,0 +1,30 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_jvn",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_jvn": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/a:hitachi_abb_power_grids:afs660:1.0.0",
+            "cpe:/o:nec:aterm_wg2600hp2_firmware",
+            "cpe:/a:cybozu:garoon",
+            "cpe:/a:cybozu:office",
+            "cpe:/a:sixapart:movable_type",
+            "cpe:/a:justsystems:ichitaro",
+            "cpe:/a:weseek:growi",
+            "cpe:/a:fujielectric:v-server",
+            "cpe:/a:basercms:basercms",
+            "cpe:/a:ec-cube:ec-cube"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/results/cpe_kernel.json
+++ b/data/results/cpe_kernel.json
@@ -1,0 +1,21 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_kernel",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_kernel": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/o:linux:linux_kernel:6.1"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/results/cpe_nvd.json
+++ b/data/results/cpe_nvd.json
@@ -1,0 +1,28 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_nvd",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_nvd": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/a:openssl:openssl:1.0.2k",
+            "cpe:/a:openssl:openssl:1.1.1w",
+            "cpe:/a:rubyonrails:rails:3.0.1",
+            "cpe:/a:apache:tomcat:7.0.27",
+            "cpe:/a:apache:http_server:2.4.49",
+            "cpe:/a:php:php:7.0.0",
+            "cpe:/a:apache:struts:2.5.10",
+            "cpe:/a:wordpress:wordpress:5.0"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/results/cpe_paloalto.json
+++ b/data/results/cpe_paloalto.json
@@ -1,0 +1,29 @@
+{
+  "jsonVersion": 4,
+  "serverName": "cpe_paloalto",
+  "family": "pseudo",
+  "release": "",
+  "scannedAt": "2026-01-01T00:00:00Z",
+  "scannedCves": {},
+  "packages": {},
+  "config": {
+    "scan": {
+      "servers": {
+        "cpe_paloalto": {
+          "type": "pseudo",
+          "cpeNames": [
+            "cpe:/o:paloaltonetworks:pan-os:7.1.0",
+            "cpe:/o:paloaltonetworks:pan-os:8.1.0",
+            "cpe:/o:paloaltonetworks:pan-os:9.0.0",
+            "cpe:/o:paloaltonetworks:pan-os:9.1.0",
+            "cpe:/o:paloaltonetworks:pan-os:10.1.0",
+            "cpe:/o:paloaltonetworks:pan-os:10.2.0",
+            "cpe:/o:paloaltonetworks:pan-os:11.0.0",
+            "cpe:/a:paloaltonetworks:globalprotect_app:5.1.0",
+            "cpe:/a:paloaltonetworks:cortex_xdr_agent:7.5.0"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

`vuls diff detection` now judges change rates per (scan-result file, data source) (MaineK00n/vuls2#400), but the fixture set has no CPE coverage — the cpe ecosystem's sources (nvd, jvn, cisco, fortinet, paloalto, vulncheck) are exercised by no scan result at all.

## What

Five pseudo-server scan results (`type: "pseudo"` servers with `cpeNames` embedded in `config.scan.servers`), one per targeted source:

| File | cpeNames | Intended source (baseline CVEs on the current nightly DB) |
|---|---|---|
| `cpe_nvd.json` | openssl 1.0.2k / 1.1.1w, rails, tomcat, httpd, php, struts, wordpress | nvd-feed-cve-v2 (509), vulncheck-nist-nvd2 (24) |
| `cpe_jvn.json` | hitachi-abb afs660, nec aterm, cybozu garoon / office, movable type, ichitaro, growi, fuji electric v-server, basercms, ec-cube | jvn-feed-rss (121) |
| `cpe_cisco.json` | ios 15.1 / 15.2, ios_xe 16.3.1 / 17.3.1, asa 9.8.1 / 9.12.4 | cisco-json (265) |
| `cpe_fortinet.json` | fortios 5.6 / 6.0 / 6.4 / 7.0, fortiproxy, fortiweb, fortimanager, fortianalyzer, forticlient | fortinet-cvrf (160) / fortinet-csaf (37) |
| `cpe_paloalto.json` | pan-os 7.1–11.0 (×7), globalprotect, cortex xdr | paloalto-json (241) |
| `cpe_kernel.json` | linux_kernel 6.1 | nvd-feed-cve-v2 (6,057), vulncheck-nist-nvd2 (1,129) |

CPE lists are sized so each intended source keeps a healthy baseline (single-CVE churn stays well under the 5% detection threshold); fortinet-csaf caps at ~37 because the whole source holds only 158 roots. The openssl entries deliberately use letter-suffixed versions (1.0.2k, 1.1.1w) so suffix comparison is exercised. The kernel sits in its own file: its volume would dominate cpe_nvd's per-source rows and mask the smaller products there, and its churn (the heaviest of any product) stays independently tunable via cpe_kernel/<source> override keys; the versioned CPE keeps range criteria evaluated (versionless matches 14k+ CVEs via the vendor-product fallback).

Validated against real DB digests: with identical DBs on both sides every (file, source) row is 0% with the baselines above, and against the diverging 2026-07-09 pair these fixtures exposed the vulncheck-nist-nvd2 detection regression (60–75% of its detections lost) that the file-level CVE-set diff had passed.

## Rollout

Inert until vulsio/vuls-data-db bumps the diff-guard `integration_ref` past this commit (follow-up PR there also drops `cpe_*.json` from the older-vuls0 detection step, whose pinned vuls0 predates CPE-via-vuls2 routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
